### PR TITLE
Fixed image upload crashing project on first image

### DIFF
--- a/CallejoIncChildcareAPI/CallejoIncChildcareAPI.csproj
+++ b/CallejoIncChildcareAPI/CallejoIncChildcareAPI.csproj
@@ -36,4 +36,8 @@
     </ProjectReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="wwwroot\images\photos\" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Manually created the /wwwroot/images/photos directory in CallejoChildcareAPI
- This resolves the issue where the app would crash on the first image upload due to the directory missing.